### PR TITLE
Misc fixes for CI runs

### DIFF
--- a/Adafruit_HTU31D.cpp
+++ b/Adafruit_HTU31D.cpp
@@ -114,9 +114,9 @@ uint32_t Adafruit_HTU31D::readSerial(void) {
   serial <<= 8;
   serial |= reply[1];
   serial <<= 8;
-  serial |= reply[3];
+  serial |= reply[2];
   serial <<= 8;
-  serial |= reply[4];
+  serial |= reply[3];
   return serial;
 }
 
@@ -218,7 +218,7 @@ void Adafruit_HTU31D::fillHumidityEvent(sensors_event_t *humidity,
   memset(humidity, 0, sizeof(sensors_event_t));
   humidity->version = sizeof(sensors_event_t);
   humidity->sensor_id = _sensorid_humidity;
-  humidity->type = SENSOR_TYPE_AMBIENT_TEMPERATURE;
+  humidity->type = SENSOR_TYPE_RELATIVE_HUMIDITY;
   humidity->timestamp = timestamp;
   humidity->relative_humidity = _humidity;
 }

--- a/Adafruit_HTU31D.cpp
+++ b/Adafruit_HTU31D.cpp
@@ -27,6 +27,8 @@
 
 #include "Adafruit_HTU31D.h"
 
+static uint8_t htu31d_crc(uint16_t value);
+
 /**
  * Constructor for the HTU31D driver.
  */

--- a/Adafruit_HTU31D.h
+++ b/Adafruit_HTU31D.h
@@ -30,8 +30,6 @@
 /** Reset command. */
 #define HTU31D_RESET (0x1E)
 
-static uint8_t htu31d_crc(uint16_t value);
-
 class Adafruit_HTU31D;
 
 /**

--- a/examples/htu31_oleddemo/htu31_oleddemo.ino
+++ b/examples/htu31_oleddemo/htu31_oleddemo.ino
@@ -2,13 +2,13 @@
 #include <Adafruit_HTU31D.h>
 #include <Fonts/FreeSans9pt7b.h>
 
-Adafruit_SH110X display = Adafruit_SH110X(64, 128, &Wire);
+Adafruit_SH1107 display = Adafruit_SH1107(64, 128, &Wire);
 Adafruit_HTU31D htu = Adafruit_HTU31D();
 
 void setup() {
   Serial.begin(115200);
   //while (!Serial);
-  
+
   Serial.println("HTU31 OLED test");
 
   Serial.println("128x64 OLED FeatherWing test");
@@ -23,17 +23,17 @@ void setup() {
   } else {
     Serial.println("Didn't find HTU31");
     while (1);
-  }  
+  }
 
   display.setRotation(1);
   display.setFont(&FreeSans9pt7b);
-  display.setTextColor(SH110X_WHITE);  
+  display.setTextColor(SH110X_WHITE);
 }
 
 void loop() {
   display.clearDisplay();
   sensors_event_t humidity, temp;
-  
+
   htu.getEvent(&humidity, &temp);// populate temp and humidity objects with fresh data
   display.setCursor(0,20);
   display.print("HTU31 Demo");
@@ -43,8 +43,8 @@ void loop() {
   display.print("Hum: "); display.print(humidity.relative_humidity); display.println(" %");
   Serial.print("Temperature: ");Serial.print(temp.temperature);Serial.println(" degrees C");
   Serial.print("Pressure: ");Serial.print(humidity.relative_humidity);Serial.println(" RH %");
-  
+
   yield();
   display.display();
-  delay(100);  
+  delay(100);
 }


### PR DESCRIPTION
Fixes a couple of minor issues that were causing CI to fail.

- Update `htu31_oleddemo.ino` to use `Adafruit_SH1107` instead of abstract base class `Adafruit_SH110X` (untested)
- Move static func `htu31d_crc` declaration to `.cpp` file. (a warn that ESP32 flags as error)